### PR TITLE
docker compose up時にnode_modulesが無くなってしまう

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     tty: true
     volumes:
       - ./frontend:/app
+      - /app/node_modules
       - ./frontend/.pnpm-store/:/app/.pnpm-store/
     ports:
       - 5173:5173


### PR DESCRIPTION
## 概要
クリーンな状態実行した際にコマンドが存在しないとエラー表示され、`pnpm install`を実行してくれとエラーが表示される

## 原因
`docker compose up` のホストの./frontendを/appにマウントする過程で`docker build`で生成された.node_moduleを上書きしてマウントしてしまうため

## 対応
/app/node_moduleをdocker volumeとして管理
## エラー内容
```bash 
docker compose up --build frontend
[+] Running 0/15s (5/11)                                                                 docker:desktop-linux
 ⠋ Service frontend  Building                                                                           15.1s 
[+] Building 25.1s (13/13) FINISHED                                                      docker:desktop-linux 
 => [frontend internal] load build definition from Dockerfile                                            0.0s
 => => transferring dockerfile: 296B                                                                     0.0s
 => [frontend internal] load metadata for docker.io/library/node:22-alpine                               2.1s
 => [frontend auth] library/node:pull token for registry-1.docker.io                                     0.0s 
 => [frontend internal] load .dockerignore                                                               0.0s 
 => => transferring context: 114B                                                                        0.0s
 => [frontend 1/6] FROM docker.io/library/node:22-alpine@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56  0.0s
 => [frontend internal] load build context                                                               5.0s 
 => => transferring context: 257.39MB                                                                    4.9s 
 => CACHED [frontend 2/6] WORKDIR /app                                                                   0.0s
 => CACHED [frontend 3/6] RUN corepack enable && corepack prepare pnpm@latest --activate                 0.0s
 => CACHED [frontend 4/6] COPY package.json pnpm-lock.yaml ./                                            0.0s
 => [frontend 5/6] RUN pnpm install                                                                      9.5s 
 => [frontend 6/6] COPY . .                                                                              4.0s 
 => [frontend] exporting to image                                                                        4.4s 
 => => exporting layers                                                                                  4.4s 
 => => writing image sha256:b013728b5fb45d427d8e8ab8abd1368edc619381ed88e51a66ebfb550926870c             0.0s 
[+] Running 2/2o docker.io/library/cnd-handson-app-frontend                                              0.0s 
 ✔ Service frontend    Built                                                                            25.2s 
 ✔ Container frontend  Recreated                                                                        10.6s 
Attaching to frontend
frontend  | 
frontend  | > app@0.0.0 dev /app
frontend  | > vite --host
frontend  | 
frontend  | sh: vite: not found
frontend  |  ELIFECYCLE  Command failed.
frontend  |  WARN   Local package.json exists, but node_modules missing, did you mean to install?
frontend exited with code 1
```