### PR TITLE
PythonのLintについて

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -110,7 +110,7 @@ jobs:
         
         - name: Lint with Flake8
           working-directory: ./${{ matrix.path }}
-          run: flake8 .
+          run: flake8 . --exclude=venv,proto --ignore=E501
         
         - name: Format check with Black
           working-directory: ./${{ matrix.path }}


### PR DESCRIPTION
自動生成されるproto系や仮想環境用のコードを除外するようにしています。

E501は文字数過多のエラーで、関数名やURL等でエラー出ているのでignoreしたいです。